### PR TITLE
Allow null for outputDigits option in the type

### DIFF
--- a/.changeset/grumpy-bobcats-visit.md
+++ b/.changeset/grumpy-bobcats-visit.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/totp": patch
+---
+
+Fix type for outputDigits to allow null

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -134,7 +134,7 @@ interface TotpGenerationOptions {
   /** Number of decimal digits in the generated TOTP
    * @note defaults to 6
    * @note set to `null` for no truncation */
-  outputDigits?: number
+  outputDigits?: number | null
 }
 
 export type TotpOptions = Partial<TotpGenerationOptions & TotpValidationOptions> & Required<Pick<TotpGenerationOptions, 'secret'>>


### PR DESCRIPTION
Fix typescript issue where `outputDigits` option didn't allow `null`.